### PR TITLE
making class static, fixing issue where RetryInterval was using wrong property

### DIFF
--- a/RetryOperationHelper/RetryOperationHelper.cs
+++ b/RetryOperationHelper/RetryOperationHelper.cs
@@ -5,14 +5,11 @@ namespace Microsoft.Samples
 {
     /// <summary>
     /// Provides functionality to automatically try the given piece of logic some number of times before re-throwing the exception. 
-    /// This is useful for any piece of code which may experience transient failures. Be cautios of passing code with two distinct 
+    /// This is useful for any piece of code which may experience transient failures. Be cautious of passing code with two distinct 
     /// actions given that if the second or subsequent piece of logic fails, the first will also be retried upon each retry. 
     /// </summary>
-    public class RetryOperationHelper
+    public static class RetryOperationHelper
     {
-        /// <summary>Gets or sets the retry interval.</summary>
-        public TimeSpan? RetryInterval { get; set; }
-
         /// <summary>Executes asynchronous function with retry logic.</summary>
         /// <param name="func">The asynchronous function to be executed.</param>
         /// <param name="maxAttempts">The maximum number of attempts.</param>
@@ -20,8 +17,13 @@ namespace Microsoft.Samples
         /// <param name="onAttemptFailed">The callback executed when an attempt is failed.</param>
         /// <typeparam name="T">The result type.</typeparam>
         /// <returns>The <see cref="Task"/> producing the result.</returns>
-        public async Task<T> ExecuteWithRetry<T>(Func<Task<T>> func, int maxAttempts, TimeSpan? retryInterval = null, Action<int, Exception> onAttemptFailed = null)
+        public static async Task<T> ExecuteWithRetry<T>(Func<Task<T>> func, int maxAttempts, TimeSpan? retryInterval = null, Action<int, Exception> onAttemptFailed = null)
         {
+            if (func == null)
+            {
+                throw new ArgumentNullException(nameof(func));
+            }
+
             if (maxAttempts < 1)
             {
                 throw new ArgumentOutOfRangeException(nameof(maxAttempts), maxAttempts, "The maximum number of attempts must not be less than 1.");
@@ -31,9 +33,9 @@ namespace Microsoft.Samples
 
             while (true)
             {
-                if (attempt > 0 && this.RetryInterval != null)
+                if (attempt > 0 && retryInterval != null)
                 {
-                    await Task.Delay(this.RetryInterval.Value);
+                    await Task.Delay(retryInterval.Value);
                 }
 
                 try
@@ -64,15 +66,20 @@ namespace Microsoft.Samples
         /// <param name="retryInterval">Timespan to wait between attempts of the operation</param>
         /// <param name="onAttemptFailed">The retry handler.</param>
         /// <returns>The <see cref="Task"/> producing the result.</returns>
-        public async Task ExecuteWithRetry(Func<Task> func, int maxAttempts, TimeSpan? retryInterval = null, Action<int, Exception> onAttemptFailed = null)
+        public static async Task ExecuteWithRetry(Func<Task> func, int maxAttempts, TimeSpan? retryInterval = null, Action<int, Exception> onAttemptFailed = null)
         {
+            if (func == null)
+            {
+                throw new ArgumentNullException(nameof(func));
+            }
+
             Func<Task<bool>> wrapper = async () =>
             {
                 await func().ConfigureAwait(false);
                 return true;
             };
 
-            await this.ExecuteWithRetry(wrapper, maxAttempts, retryInterval, onAttemptFailed);
+            await RetryOperationHelper.ExecuteWithRetry(wrapper, maxAttempts, retryInterval, onAttemptFailed);
         }
     }
 }

--- a/RetryOperationHelperUnitTests/RetryOperationHelperUnitTests.cs
+++ b/RetryOperationHelperUnitTests/RetryOperationHelperUnitTests.cs
@@ -15,12 +15,11 @@ namespace RetryOperationHelperUnitTests
             const int numberOfRetriesToAttempt = 3;
             const int numberOfFailuresToSimulate = 2;
 
-            var retryLogic = new RetryOperationHelper();
             var operationSimulator = new OperationSimulator(numberOfFailuresToSimulate);
             Func<Task<bool>> func = () => operationSimulator.SimulateOperationWithFailures();
 
             //Act
-            var result = retryLogic.ExecuteWithRetry(func, numberOfRetriesToAttempt).Result;
+            var result = RetryOperationHelper.ExecuteWithRetry(func, numberOfRetriesToAttempt).Result;
 
             //Assert 
             Assert.Equal(result, true);
@@ -33,12 +32,11 @@ namespace RetryOperationHelperUnitTests
             const int numberOfRetriesToAttempt = 3;
             const int numberOfFailuresToSimulate = 3;
 
-            var retryLogic = new RetryOperationHelper();
             var operationSimulator = new OperationSimulator(numberOfFailuresToSimulate);
             Func<Task<bool>> func = () => operationSimulator.SimulateOperationWithFailures();
 
             //Act
-            Exception ex = Assert.Throws<AggregateException>(() => retryLogic.ExecuteWithRetry(func, numberOfRetriesToAttempt).Wait());
+            Exception ex = Assert.Throws<AggregateException>(() => RetryOperationHelper.ExecuteWithRetry(func, numberOfRetriesToAttempt).Wait());
             Assert.Equal(ex.InnerException.Message, "OperationSimulator: Simulating Operation Failure");
         }
 
@@ -50,13 +48,12 @@ namespace RetryOperationHelperUnitTests
             const int numberOfFailuresToSimulate = 3;
             TimeSpan retryTimeSpan = new TimeSpan(0, 0, 0, 1);
 
-            var retryLogic = new RetryOperationHelper();
             var operationSimulator = new OperationSimulator(numberOfFailuresToSimulate);
             Func<Task<bool>> func = () => operationSimulator.SimulateOperationWithFailures();
             Action<int, Exception> actionUponFailure = new Action<int, Exception>(operationSimulator.ThrowException);
 
             //Act
-            Exception ex = Assert.Throws<AggregateException>(() => retryLogic.ExecuteWithRetry(func, numberOfRetriesToAttempt, retryTimeSpan, actionUponFailure).Wait());
+            Exception ex = Assert.Throws<AggregateException>(() => RetryOperationHelper.ExecuteWithRetry(func, numberOfRetriesToAttempt, retryTimeSpan, actionUponFailure).Wait());
             Assert.Equal(ex.InnerException.Message, "OperationSimulator: ThrowException: Exception thrown to identify method");
         }
     }


### PR DESCRIPTION
Making the class static because there doesn't appear to be any reason why it shouldn't be.

Also fixing issue where the retryInterval in the method was referencing a class property, instead of the TimeSpan parameter being passed in. 
